### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Properties:
 ### Linux manual
 
 ```sh
-go install github.com/pltanton/autobrowser/cmd/autobrowser-linux
+go install github.com/pltanton/autobrowser/cmd/autobrowser-linux@latest
 ```
 
 Create config at `~/.config/autobrowser.config`.


### PR DESCRIPTION
On Mac, on clean install, I get this error:
```
go install github.com/pltanton/autobrowser/cmd/autobrowser-linux

go: 'go install' requires a version when current directory is not in a module
Try 'go install github.com/pltanton/autobrowser/cmd/autobrowser-linux@latest' to install the latest version
```